### PR TITLE
add testing CI workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,11 @@ on:
     branches: [ main ]
   pull_request:
 
+# Cancel in-progress runs when a new run is triggered on the same branch
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,127 @@
+name: Test TypeScript SDK
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: ['22','24','25']
+      fail-fast: false  # Continue testing other versions even if one fails
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Set up Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'npm'  # Cache npm dependencies for faster builds
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build SDK (tshy - dual CJS/ESM)
+        run: npm run build
+
+      - name: Verify build outputs
+        run: |
+          echo "Checking CommonJS build..."
+          ls -la dist/commonjs/
+          echo "Checking ESM build..."
+          ls -la dist/esm/
+
+      - name: Run integration tests
+        env:
+          SUDO_API_KEY: ${{ secrets.SUDO_API_KEY }}
+          SUDO_SERVER_URL: https://sudoapp.dev/api
+        run: npm run test:integration
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results-node-${{ matrix.node-version }}
+          path: test-results/
+          retention-days: 30
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run linter
+        run: npm run lint
+
+  type-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Type check
+        run: npx tsc --noEmit
+
+  # Test that the package can be imported in both CJS and ESM contexts
+  test-package-compatibility:
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies and build
+        run: |
+          npm ci
+          npm run build
+
+      - name: Test CommonJS import
+        run: |
+          node --input-type=commonjs -e "const sdk = require('./dist/commonjs/index.js'); console.log('✓ CJS import works');"
+
+      - name: Test ESM import
+        run: |
+          node --input-type=module -e "import('./dist/esm/index.js').then(() => console.log('✓ ESM import works'));"
+
+  # Summary job that all other jobs depend on
+  test-summary:
+    runs-on: ubuntu-latest
+    needs: [test, lint, type-check, test-package-compatibility]
+    if: always()
+    steps:
+      - name: Check test results
+        run: |
+          if [[ "${{ needs.test.result }}" == "failure" || "${{ needs.lint.result }}" == "failure" || "${{ needs.type-check.result }}" == "failure" || "${{ needs.test-package-compatibility.result }}" == "failure" ]]; then
+            echo "Tests, linting, type checking, or package compatibility failed"
+            exit 1
+          fi
+          echo "All checks passed!"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,7 @@ name: Test TypeScript SDK
 
 on:
   push:
+    branches: [ main ]
   pull_request:
 
 jobs:


### PR DESCRIPTION
Adds CI to test Typescript SDK against public Sudo endpoint
Tests with Node 22, 24, and 25, can adjust this as desired.